### PR TITLE
Allow boot development without carrierwave.

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,17 +1,17 @@
 CarrierWave.configure do |config|
   config.fog_credentials = {
-      # Configuration for Amazon S3 should be made available through an Environment variable.
-      # For local installations, export the env variable through the shell OR
-      # if using Passenger, set an Apache environment variable.
-      #
-      # In Heroku, follow http://devcenter.heroku.com/articles/config-vars
-      #
-      # $ heroku config:add S3_KEY=your_s3_access_key S3_SECRET=your_s3_secret S3_REGION=eu-west-1 S3_ASSET_URL=http://assets.example.com/ S3_BUCKET_NAME=s3_bucket/folder
+    # Configuration for Amazon S3 should be made available through an Environment variable.
+    # For local installations, export the env variable through the shell OR
+    # if using Passenger, set an Apache environment variable.
+    #
+    # In Heroku, follow http://devcenter.heroku.com/articles/config-vars
+    #
+    # $ heroku config:add S3_KEY=your_s3_access_key S3_SECRET=your_s3_secret S3_REGION=eu-west-1 S3_ASSET_URL=http://assets.example.com/ S3_BUCKET_NAME=s3_bucket/folder
 
-      # Configuration for Amazon S3
-      :provider              => 'AWS',
-      :aws_access_key_id     => ENV['AWS_ACCESS_KEY_ID'],
-      :aws_secret_access_key => ENV['AWS_SECRET_KEY']
+    # Configuration for Amazon S3
+    :provider              => 'AWS',
+    :aws_access_key_id     => ENV.fetch("AWS_ACCESS_KEY_ID", ""),
+    :aws_secret_access_key => ENV.fetch("AWS_SECRET_KEY", "")
   }
 
   # For testing, upload files to local `tmp` folder.


### PR DESCRIPTION
This doesn't solve the problem of letting image uploads work in development but it lets the server boot without carrierwave.

closes anthonymidili/EasyKeep#60